### PR TITLE
feat(ContactSelector): fade out long names in ContactSelector's chips

### DIFF
--- a/src/components/ContactSelector/ContactSelector.css
+++ b/src/components/ContactSelector/ContactSelector.css
@@ -53,6 +53,7 @@
 }
 
 .chipText {
+  position: relative;
   margin: 0 10px;
   font-size: var(--default-font-size);
   font-weight: 500;
@@ -61,6 +62,20 @@
   letter-spacing: -0.3px;
   max-width: var(--contact-selector-chip-text-max-width);
   @mixin text-overflow-ellipsis;
+}
+
+.chipText:after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: var(--contact-selector-chip-text-max-width);
+  height: 100%;
+  background: linear-gradient(
+    to right,
+    transparent 85%,
+    var(--contact-selector-chip-background)
+  );
 }
 
 /* .chipAvatar {} */


### PR DESCRIPTION

<img width="534" alt="Screenshot 2019-04-10 at 19 39 35" src="https://user-images.githubusercontent.com/15225608/55938382-f127ea80-5c43-11e9-83cd-cd76cf4e30d7.png">
